### PR TITLE
State management 방식 수정 + init 실행 중간에 끊어질때 상태관리 안되는 버그 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,16 @@ MacOS에서만 사용이 가능한 로컬 Kubernetes 클러스터 관리 도구�
   ```
 
   - 옵션:
-    - `--config`, `-c`: 클러스터 설정파일 경로 (기본값: `<executed-path>/cluster-config.json`)
     - `--force`, `-f`: 기존 클러스터가 있으면 삭제 후 재생성
+
+- **클러스터 config 수정**: `config`
+
+  ```
+  kluster config [sub command]
+  ```
+
+  - 서브커맨드
+    - `edit`: cluster-config.json 파일을 vim으로 열음
 
 - **특정 노드 VM Shell 접속**: `shell`
 

--- a/kluster/command/action_base.py
+++ b/kluster/command/action_base.py
@@ -1,5 +1,5 @@
 import argparse
-from kluster.command.actions import init, destroy, shell, doctor
+from kluster.command.actions import init, destroy, shell, doctor, config
 
 
 def action_parser(parser: argparse.ArgumentParser):
@@ -24,6 +24,16 @@ def action_parser(parser: argparse.ArgumentParser):
         action="store_true",
     )
     init_action.set_defaults(func=init.run)
+
+    # Configuration for sub command - config
+    config_parser = action_parser.add_parser("config", help="Manage cluster configuration")
+    config_subparsers = config_parser.add_subparsers(
+        title="Config actions", dest="config_action", help="Configuration actions"
+    )
+    config_subparsers.required = True
+    # Subcommand for sub command - kluster config
+    edit_parser = config_subparsers.add_parser("edit", help="Edit cluster configuration")
+    edit_parser.set_defaults(func=config.edit)
 
     # Configuration for sub command - destroy
     destroy_parser = action_parser.add_parser("destroy", help="Destroy the cluster")

--- a/kluster/command/actions/config.py
+++ b/kluster/command/actions/config.py
@@ -1,0 +1,21 @@
+import os
+import subprocess
+from kluster.constant import DEFAULT_CONFIG_PATH
+from kluster.utils import logger
+from kluster.utils.dependency import require_dependencies
+from kluster.utils.config import create_default_config
+
+@require_dependencies(dependencies=["vim"])
+def edit(args):
+    if not os.path.exists(DEFAULT_CONFIG_PATH):
+        logger.log(f"⚠️ Config file not found at {DEFAULT_CONFIG_PATH}")
+        logger.log(f"🔄 Creating default configuration...")
+        create_default_config()
+    
+    try:
+        logger.log(f"🚀 Opening cluster config file")
+        subprocess.run(["vim", DEFAULT_CONFIG_PATH])
+        return 0
+    except Exception as e:
+        logger.error(f"❌ Error editing configuration: {e}")
+        return 1

--- a/kluster/command/actions/init.py
+++ b/kluster/command/actions/init.py
@@ -376,7 +376,8 @@ def run(args):
             insert_node_to_db(
                 cursor, node_name, node_type, cpu, memory, disk, node_config
             )
-
+        
+        connection.commit()
         # 지금 보니까 Go로 작성된 버전은 마스터노드 검사하는게 없었네...
         if master_node_count == 0:
             logger.error("Kubernetes cluster must have at least one master node")

--- a/kluster/command/actions/init.py
+++ b/kluster/command/actions/init.py
@@ -12,6 +12,7 @@ from kluster.command.actions.init_multipass import check_and_download_image, cre
 from kluster.command.actions.destroy import run as destroy_run
 from kluster.utils.dependency import require_dependencies
 from kluster.utils import logger
+from kluster.utils.config import create_default_config
 
 
 def config_deserializer(config_path):
@@ -295,20 +296,16 @@ Command:
         return False
 
 
-@require_dependencies()
+@require_dependencies(dependencies=["kubectl","multipass"])
 def run(args):
-    if not os.path.isabs(args.config):
-        current_dir_config = os.path.join(os.getcwd(), args.config)
-        if os.path.exists(current_dir_config):
-            config_path = current_dir_config
-        else:
-            config_path = DEFAULT_CONFIG_PATH
+    if not os.path.exists(DEFAULT_CONFIG_PATH):
+        logger.log(f"⚠️ Config file not found at {DEFAULT_CONFIG_PATH}")
+        logger.log(f"🔄 Creating default configuration...")
+        config = create_default_config()
     else:
-        config_path = args.config
-
-    config = config_deserializer(config_path)
-    if not config:
-        return 1
+        config = config_deserializer(DEFAULT_CONFIG_PATH)
+        if not config:
+            return 1
 
     db_path = SQLITE_PATH
 

--- a/kluster/constant.py
+++ b/kluster/constant.py
@@ -5,4 +5,5 @@ CLUSTER_PATH = os.path.dirname(os.path.abspath(__file__))
 PROJECT_ROOT = os.path.dirname(CLUSTER_PATH)
 SQLITE_PATH = os.path.join(CLUSTER_PATH, "database.db")
 SCRIPTS_PATH = os.path.join(CLUSTER_PATH, "scripts")
+# 나중에 한번에 변수명 바꾸자... 지금은 귀찮다... Default config path 대신 Cluster Config Path로 변경해야함
 DEFAULT_CONFIG_PATH = os.path.join(PROJECT_ROOT, "cluster-config.json")

--- a/kluster/utils/config.py
+++ b/kluster/utils/config.py
@@ -1,0 +1,32 @@
+import os
+import json
+from kluster.constant import DEFAULT_CONFIG_PATH
+
+
+"""
+필요한 경우
+
+cluster-config.json파일이 유실되거나 고의적으로 삭제되었을때
+기본 파일로 대체하기 위함임.
+"""
+def create_default_config():
+    default_config = {
+        "k3s_version": "v1.26.6+k3s1",
+        "ubuntu_version": "22.04",
+        "nodes": {
+            "master-1": {
+                "type": "master",
+                "cpu": 2,
+                "memory": 2048,
+                "disk": 10,
+                "ip": ""
+            }
+        }
+    }
+    
+    os.makedirs(os.path.dirname(DEFAULT_CONFIG_PATH), exist_ok=True)
+    
+    with open(DEFAULT_CONFIG_PATH, 'w') as f:
+        json.dump(default_config, f, indent=2)
+    
+    return default_config

--- a/kluster/utils/dependency.py
+++ b/kluster/utils/dependency.py
@@ -3,11 +3,11 @@ import functools
 from kluster.utils import logger
 
 
-def require_dependencies(is_doctor: bool = False):
+def require_dependencies(dependencies=None, is_doctor: bool = False):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(args):
-            if not _check_dependencies(is_doctor=is_doctor):
+            if not _check_dependencies(dependencies, is_doctor=is_doctor):
                 return 1
             return func(args)
 
@@ -16,13 +16,18 @@ def require_dependencies(is_doctor: bool = False):
     return decorator
 
 
-def _check_dependencies(is_doctor: bool = False):
-    required_tools = {"kubectl": True, "multipass": True, "helm": False}
+def _check_dependencies(specific_dependencies=None, is_doctor: bool = False):
+    required_tools = {"kubectl": True, "multipass": True, "helm": False, "vim": True}
+    
+    if specific_dependencies:
+        tools_to_check = {tool: required_tools.get(tool, True) for tool in specific_dependencies}
+    else:
+        tools_to_check = required_tools
 
     all_installed = True
     status_messages = []
 
-    for tool, is_required in required_tools.items():
+    for tool, is_required in tools_to_check.items():
         is_installed = shutil.which(tool) is not None
         status = "✅" if is_installed else "❌"
         not_required = " (Not Required)" if not is_required else ""


### PR DESCRIPTION
- `init` 명령어에서 특정 config file 받는 옵션 삭제 (`--config`플래그)
- cluster-config는 앞으로 `kluster config edit`으로 수정하도록함(config파일은 중앙에서만 관리하도록)
  - 사용자가 임의로 삭제하면 기본 config가 생성되는 방식으로 진행
- `init` 실행 중간에 끊고 destroy하면 저장값이 없어서 destroy 실패하는 문제 해결